### PR TITLE
fix: Remove base value for rem units

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -60,11 +60,3 @@
   font-style: italic;
   src: url('./fonts/open-sans-v27-latin-800italic.woff2') format('woff2');
 }
-
-/* Set 1rem size to 10px but keep the default font size the same */
-html {
-  font-size: 0.625rem;
-}
-body {
-  font-size: 1.4rem;
-}


### PR DESCRIPTION
We no longer use rems in our source code. I suggest to remove this global styles, as we kept it for backward compatibility reasons.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
