### PR TITLE
chore: Add release gh notes workflow

### DIFF
--- a/.github/workflows/release-gh-notes.yml
+++ b/.github/workflows/release-gh-notes.yml
@@ -1,0 +1,20 @@
+name: Release Github notes
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        required: true
+        description: 'Specify the version for this release'
+        type: string
+      npm_package:
+        required: true
+        description: 'npm package of the release repo'
+        type: string
+jobs:
+  release:
+    uses: cloudscape-design/.github/.github/workflows/release-gh-notes.yml@main
+    secrets: inherit
+    with:
+      npm_package: ${{ github.event.inputs.npm_package }}
+      version: ${{ github.event.inputs.version }}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Add a workflow to release github notes to this repository, this workflow calls the main [workflow](https://github.com/cloudscape-design/.github/blob/main/.github/workflows/release-gh-notes.yml)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
