### PR TITLE
chore: Add content write permissions to release notes workflow

### DIFF
--- a/.github/workflows/release-gh-notes.yml
+++ b/.github/workflows/release-gh-notes.yml
@@ -11,6 +11,10 @@ on:
         required: true
         description: 'npm package of the release repo'
         type: string
+
+permissions:
+  contents: write
+
 jobs:
   release:
     uses: cloudscape-design/.github/.github/workflows/release-gh-notes.yml@main


### PR DESCRIPTION
*Description of changes:*

Add content write permissions to release notes workflow, the current repository settings needs explicit permissions for github actions to create release notes in the repository

tested in https://github.com/cloudscape-design/components/pull/481

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
