### PR TITLE
feat: Add default text color

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -61,6 +61,15 @@
   src: url('./fonts/open-sans-v27-latin-800italic.woff2') format('woff2');
 }
 
+
 .awsui-dark-mode {
   color-scheme: dark;
 }
+
+body{
+  color: #000716;
+}
+
+body.awsui-dark-mode, body .awsui-dark-mode{
+    color: #d1d5db;
+  }


### PR DESCRIPTION
Issue #AWSUI-20480

Spinner with `normal` variant picks up the current color of its context. If there is no color defined in parent elements it is using the default black color. Adding `$color-text-body-default` color to body or themed node, to make sure the default text color is correct.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
