### PR TITLE
chore: Deprecate npm_package argument

### DIFF
--- a/.github/workflows/release-gh-notes.yml
+++ b/.github/workflows/release-gh-notes.yml
@@ -8,11 +8,11 @@ on:
         description: 'Specify the version for this release'
         type: string
       npm_package:
-        required: true
-        description: 'npm package of the release repo'
+        required: false
+        description: 'npm package of the release repo (deprecated)'
         type: string
       commit:
-        required: false
+        required: true
         description: 'commit to generate release notes'
         type: string
 


### PR DESCRIPTION
Following https://github.com/cloudscape-design/actions/pull/5 we can now cleanup the unused argument.

First, we mark it here as optional, then remove from the main workflow and then doing the final cleanup here.

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
