### PR TITLE
chore: Upgrade Vite to 6.0.11

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6090,9 +6090,9 @@
       }
     },
     "node_modules/vite-node/node_modules/vite": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-6.0.1.tgz",
-      "integrity": "sha512-Ldn6gorLGr4mCdFnmeAOLweJxZ34HjKnDm4HGo6P66IEqTxQb36VEdFJQENKxWjupNfoIjvRUnswjn1hpYEpjQ==",
+      "version": "6.0.11",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-6.0.11.tgz",
+      "integrity": "sha512-4VL9mQPKoHy4+FE0NnRE/kbY51TOfaknxAjt3fJbGJxhIpBZiqVzlZDEesWWsuREXHwNdAoOFZ9MkPEVXczHwg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6270,9 +6270,9 @@
       }
     },
     "node_modules/vitest/node_modules/vite": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-6.0.1.tgz",
-      "integrity": "sha512-Ldn6gorLGr4mCdFnmeAOLweJxZ34HjKnDm4HGo6P66IEqTxQb36VEdFJQENKxWjupNfoIjvRUnswjn1hpYEpjQ==",
+      "version": "6.0.11",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-6.0.11.tgz",
+      "integrity": "sha512-4VL9mQPKoHy4+FE0NnRE/kbY51TOfaknxAjt3fJbGJxhIpBZiqVzlZDEesWWsuREXHwNdAoOFZ9MkPEVXczHwg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {


### PR DESCRIPTION
*Issue #, if available:* Resolves [dependabot alert #17](https://github.com/cloudscape-design/global-styles/security/dependabot/17).

Ran `npm audit fix` and removed some unnecessary changes. Confirmed they were unnecessary by running `npm ci` and noting it didn't yell at me.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
